### PR TITLE
Fixed booflo compatibility being broken

### DIFF
--- a/src/main/java/com/minecraftabnormals/endergetic/common/entities/booflo/BoofloAdolescentEntity.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/common/entities/booflo/BoofloAdolescentEntity.java
@@ -2,6 +2,7 @@ package com.minecraftabnormals.endergetic.common.entities.booflo;
 
 import javax.annotation.Nullable;
 
+import com.teamabnormals.abnormals_core.core.library.api.IAgeableEntity;
 import com.teamabnormals.abnormals_core.core.library.endimator.Endimation;
 import com.teamabnormals.abnormals_core.core.library.endimator.entity.EndimatedEntity;
 import com.teamabnormals.abnormals_core.core.utils.NetworkUtil;
@@ -60,7 +61,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 /**
  * @author - SmellyModder(Luke Tonon)
  */
-public class BoofloAdolescentEntity extends EndimatedEntity {
+public class BoofloAdolescentEntity extends EndimatedEntity implements IAgeableEntity {
 	private static final DataParameter<Boolean> MOVING = EntityDataManager.createKey(BoofloAdolescentEntity.class, DataSerializers.BOOLEAN);
 	private static final DataParameter<Boolean> HAS_FRUIT = EntityDataManager.createKey(BoofloAdolescentEntity.class, DataSerializers.BOOLEAN);
 	private static final DataParameter<Boolean> DESCENTING = EntityDataManager.createKey(BoofloAdolescentEntity.class, DataSerializers.BOOLEAN);

--- a/src/main/java/com/minecraftabnormals/endergetic/common/entities/booflo/BoofloBabyEntity.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/common/entities/booflo/BoofloBabyEntity.java
@@ -2,6 +2,7 @@ package com.minecraftabnormals.endergetic.common.entities.booflo;
 
 import javax.annotation.Nullable;
 
+import com.teamabnormals.abnormals_core.core.library.api.IAgeableEntity;
 import com.teamabnormals.abnormals_core.core.library.endimator.Endimation;
 import com.teamabnormals.abnormals_core.core.library.endimator.entity.EndimatedEntity;
 import com.minecraftabnormals.endergetic.api.entity.util.EntityItemStackHelper;
@@ -45,7 +46,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-public class BoofloBabyEntity extends EndimatedEntity {
+public class BoofloBabyEntity extends EndimatedEntity implements IAgeableEntity {
 	private static final DataParameter<Boolean> MOVING = EntityDataManager.createKey(BoofloBabyEntity.class, DataSerializers.BOOLEAN);
 	public static final DataParameter<Boolean> BEING_BORN = EntityDataManager.createKey(BoofloBabyEntity.class, DataSerializers.BOOLEAN);
 	public static final DataParameter<Integer> MOTHER_IMMUNITY_TICKS = EntityDataManager.createKey(BoofloBabyEntity.class, DataSerializers.VARINT);

--- a/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
 
 /**
- * @author tessdotcpp
+ * @author abigailfails
  * Events for compatibility with the Savage & Ravage mod.
  */
 @Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
@@ -22,7 +22,7 @@ public final class CompatEvents {
 	public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
 		LivingEntity affected = event.getEntityLiving();
 		boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
-		if (isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))) {
+		if (isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growing"))) {
 			if (!isBabyEffect && affected instanceof BoofloBabyEntity) ((BoofloBabyEntity) affected).growUp();
 			if (affected instanceof BoofloAdolescentEntity) {
 				if (isBabyEffect) {

--- a/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
@@ -6,11 +6,14 @@ import com.minecraftabnormals.endergetic.common.entities.booflo.BoofloEntity;
 import com.minecraftabnormals.endergetic.core.EndergeticExpansion;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.potion.Effect;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.entity.living.PotionEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.Objects;
 
 /**
  * @author abigailfails
@@ -18,11 +21,16 @@ import net.minecraftforge.registries.ForgeRegistries;
  */
 @Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
 public final class CompatEvents {
+
+	private static final ResourceLocation SHRINKING_ID = new ResourceLocation("savageandravage:shrinking");
+	private static final ResourceLocation GROWING_ID = new ResourceLocation("savageandravage:growing");
+
 	@SubscribeEvent
 	public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
 		LivingEntity affected = event.getEntityLiving();
-		boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
-		if (isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growing"))) {
+		Effect effectType = Objects.requireNonNull(event.getPotionEffect()).getPotion();
+		boolean isBabyEffect = effectType == ForgeRegistries.POTIONS.getValue(SHRINKING_ID);
+		if (isBabyEffect || effectType == ForgeRegistries.POTIONS.getValue(GROWING_ID)) {
 			if (!isBabyEffect && affected instanceof BoofloBabyEntity) ((BoofloBabyEntity) affected).growUp();
 			if (affected instanceof BoofloAdolescentEntity) {
 				if (isBabyEffect) {

--- a/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/events/CompatEvents.java
@@ -7,13 +7,12 @@ import com.minecraftabnormals.endergetic.core.EndergeticExpansion;
 
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.potion.Effect;
+import net.minecraft.potion.EffectInstance;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.entity.living.PotionEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.ForgeRegistries;
-
-import java.util.Objects;
 
 /**
  * @author abigailfails
@@ -21,25 +20,27 @@ import java.util.Objects;
  */
 @Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
 public final class CompatEvents {
-
 	private static final ResourceLocation SHRINKING_ID = new ResourceLocation("savageandravage:shrinking");
 	private static final ResourceLocation GROWING_ID = new ResourceLocation("savageandravage:growing");
 
 	@SubscribeEvent
 	public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
 		LivingEntity affected = event.getEntityLiving();
-		Effect effectType = Objects.requireNonNull(event.getPotionEffect()).getPotion();
-		boolean isBabyEffect = effectType == ForgeRegistries.POTIONS.getValue(SHRINKING_ID);
-		if (isBabyEffect || effectType == ForgeRegistries.POTIONS.getValue(GROWING_ID)) {
-			if (!isBabyEffect && affected instanceof BoofloBabyEntity) ((BoofloBabyEntity) affected).growUp();
-			if (affected instanceof BoofloAdolescentEntity) {
-				if (isBabyEffect) {
-					((BoofloAdolescentEntity) affected).growDown();
-				} else {
-					((BoofloAdolescentEntity) affected).growUp();
+		EffectInstance effectInstance = event.getPotionEffect();
+		if(effectInstance != null) {
+			Effect effectType = effectInstance.getPotion();
+			boolean isBabyEffect = effectType == ForgeRegistries.POTIONS.getValue(SHRINKING_ID);
+			if (isBabyEffect || effectType == ForgeRegistries.POTIONS.getValue(GROWING_ID)) {
+				if (!isBabyEffect && affected instanceof BoofloBabyEntity) ((BoofloBabyEntity) affected).growUp();
+				if (affected instanceof BoofloAdolescentEntity) {
+					if (isBabyEffect) {
+						((BoofloAdolescentEntity) affected).growDown();
+					} else {
+						((BoofloAdolescentEntity) affected).growUp();
+					}
 				}
+				if (isBabyEffect && affected instanceof BoofloEntity) ((BoofloEntity) affected).growDown();
 			}
-			if (isBabyEffect && affected instanceof BoofloEntity) ((BoofloEntity) affected).growDown();
 		}
 	}
 }


### PR DESCRIPTION
I have a horrible feeling `IAgeableEntity` was never actually implemented in the booflo classes when I added it to AC, so the poison potato compatibility never worked. Also, when S&R's growing effect id was changed to `savageandravage:growing`, the booflo compatibility with it broke as the old id was still being checked for. This PR fixes these issues.