### PR TITLE
Change spawnBalloons mixin implementation

### DIFF
--- a/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
@@ -13,7 +13,6 @@ import net.minecraft.nbt.ListNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.PlayerList;
-import net.minecraft.util.registry.DynamicRegistries;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.PlayerData;
 import net.minecraftforge.fml.network.PacketDistributor;

--- a/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
@@ -29,9 +29,11 @@ import java.util.List;
 
 @Mixin(PlayerList.class)
 public final class PlayerListMixin {
-	@Shadow @Final
+	@Shadow
+	@Final
 	private PlayerData playerDataManager;
-	@Shadow @Final
+	@Shadow
+	@Final
 	private MinecraftServer server;
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
@@ -17,7 +17,9 @@ import net.minecraft.util.registry.DynamicRegistries;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.PlayerData;
 import net.minecraftforge.fml.network.PacketDistributor;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -27,14 +29,10 @@ import java.util.List;
 
 @Mixin(PlayerList.class)
 public final class PlayerListMixin {
+	@Shadow @Final
 	private PlayerData playerDataManager;
+	@Shadow @Final
 	private MinecraftServer server;
-
-	@Inject(at = @At("RETURN"), method = "<init>")
-	private void initialize(MinecraftServer p_i231425_1_, DynamicRegistries.Impl p_i231425_2_, PlayerData p_i231425_3_, int p_i231425_4_, CallbackInfo info) {
-		playerDataManager = p_i231425_3_;
-		server = p_i231425_1_;
-	}
 
 	@SuppressWarnings("deprecation")
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/PlayerList;writePlayerData(Lnet/minecraft/entity/player/ServerPlayerEntity;)V", shift = At.Shift.AFTER), method = "playerLoggedOut")
@@ -57,11 +55,11 @@ public final class PlayerListMixin {
 		CompoundNBT compound = this.server.getServerConfiguration().getHostPlayerNBT();
 		if (!(compound != null && player.getName().getString().equals(this.server.getServerOwner()))) {
 			try {
-				File file1 = new File(this.playerDataManager.getPlayerDataFolder(), player.getCachedUniqueIdString() + ".dat");
-				if (file1.exists() && file1.isFile()) {
-					compound = CompressedStreamTools.readCompressed(file1);
+				File playerDataFile = new File(this.playerDataManager.getPlayerDataFolder(), player.getCachedUniqueIdString() + ".dat");
+				if (playerDataFile.exists() && playerDataFile.isFile()) {
+					compound = CompressedStreamTools.readCompressed(playerDataFile);
 				}
-			} catch (Exception var4) {
+			} catch (Exception exception) {
 				EndergeticExpansion.LOGGER.warn("Failed to load player data for {}", player.getName().getString());
 			}
 		}

--- a/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/mixin/PlayerListMixin.java
@@ -8,20 +8,33 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.network.NetworkManager;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.registry.DynamicRegistries;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.PlayerData;
 import net.minecraftforge.fml.network.PacketDistributor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.io.File;
 import java.util.List;
 
 @Mixin(PlayerList.class)
 public final class PlayerListMixin {
+	private PlayerData playerDataManager;
+	private MinecraftServer server;
+
+	@Inject(at = @At("RETURN"), method = "<init>")
+	private void initialize(MinecraftServer p_i231425_1_, DynamicRegistries.Impl p_i231425_2_, PlayerData p_i231425_3_, int p_i231425_4_, CallbackInfo info) {
+		playerDataManager = p_i231425_3_;
+		server = p_i231425_1_;
+	}
 
 	@SuppressWarnings("deprecation")
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/PlayerList;writePlayerData(Lnet/minecraft/entity/player/ServerPlayerEntity;)V", shift = At.Shift.AFTER), method = "playerLoggedOut")
@@ -40,7 +53,19 @@ public final class PlayerListMixin {
 	@Inject(at = @At("RETURN"), method = "initializeConnectionToPlayer")
 	private void spawnBalloons(NetworkManager netManager, ServerPlayerEntity player, CallbackInfo info) {
 		ServerWorld serverWorld = (ServerWorld) player.world;
-		CompoundNBT compound = ((PlayerList) (Object) this).readPlayerDataFromFile(player);
+
+		CompoundNBT compound = this.server.getServerConfiguration().getHostPlayerNBT();
+		if (!(compound != null && player.getName().getString().equals(this.server.getServerOwner()))) {
+			try {
+				File file1 = new File(this.playerDataManager.getPlayerDataFolder(), player.getCachedUniqueIdString() + ".dat");
+				if (file1.exists() && file1.isFile()) {
+					compound = CompressedStreamTools.readCompressed(file1);
+				}
+			} catch (Exception var4) {
+				EndergeticExpansion.LOGGER.warn("Failed to load player data for {}", player.getName().getString());
+			}
+		}
+
 		if (compound != null && compound.contains("Balloons", 9)) {
 			ListNBT balloonsTag = compound.getList("Balloons", 10);
 			if (!balloonsTag.isEmpty()) {


### PR DESCRIPTION
- Avoids calling a Player Entity's read method from being called
  multiple times when it's not necessary
- Quick fix for #162

This is only a quick fix and should be treated as a stop gap from properly implementing balloons using Capabilities.