### PR TITLE
Fixed End Crystals item consuming when entity inside the Crystal's AABB

### DIFF
--- a/src/main/java/com/minecraftabnormals/endergetic/core/mixin/EnderCrystalItemMixin.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/mixin/EnderCrystalItemMixin.java
@@ -46,9 +46,9 @@ public final class EnderCrystalItemMixin {
 							dragonfightmanager.tryRespawnDragon();
 						}
 					}
+					context.getItem().shrink(1);
+					info.setReturnValue(ActionResultType.func_233537_a_(world.isRemote));
 				}
-				context.getItem().shrink(1);
-				info.setReturnValue(ActionResultType.SUCCESS);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #188 by making shrinking the stack only if there are no entities in the Crystal's AABB.
Also changes the return value to use the vanilla method (`func_233537_a_`, `sidedSuccess` in vanilla mappings) that chooses the success ActionResult based off world.isRemote.