### PR TITLE
Register EE config values with config condition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ modName=The Endergetic Expansion
 modId=endergetic
 modVersion=3.0.0
 
-abnormalsCore=3147409
+abnormalsCore=3351059

--- a/src/main/java/com/minecraftabnormals/endergetic/core/EndergeticExpansion.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/EndergeticExpansion.java
@@ -3,6 +3,7 @@ package com.minecraftabnormals.endergetic.core;
 import com.minecraftabnormals.abnormals_core.common.world.modification.BiomeFeatureModifier;
 import com.minecraftabnormals.abnormals_core.common.world.modification.BiomeModificationManager;
 import com.minecraftabnormals.abnormals_core.common.world.modification.BiomeModificationPredicates;
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.endergetic.common.world.placements.EEPlacements;
 import com.minecraftabnormals.endergetic.core.registry.other.*;
@@ -99,6 +100,7 @@ public class EndergeticExpansion {
 
 		modEventBus.addListener(EventPriority.LOWEST, this::setupCommon);
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, EEConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(EndergeticExpansion.MOD_ID, EEConfig.COMMON);
 	}
 
 	void setupCommon(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/minecraftabnormals/endergetic/core/config/EEConfig.java
+++ b/src/main/java/com/minecraftabnormals/endergetic/core/config/EEConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.endergetic.core.config;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraftforge.common.ForgeConfigSpec;
@@ -12,6 +13,8 @@ import net.minecraftforge.fml.config.ModConfig;
 public final class EEConfig {
 
 	public static class Common {
+
+		@ConfigKey("debug_dragon_fight_manager")
 		public final ConfigValue<Boolean> debugDragonFightManager;
 
 		Common(ForgeConfigSpec.Builder builder) {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -31,6 +31,6 @@ license = "https://github.com/team-abnormals/endergetic/blob/main/LICENSE.txt"
 [[dependencies.endergetic]]
     modId = "abnormals_core"
     mandatory = true
-    versionRange = "[3.0.4,)"
+    versionRange = "[3.1.1,)"
     ordering = "AFTER"
     side = "BOTH"


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.